### PR TITLE
Update conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,5 +12,7 @@ dependencies:
     - astroquery=0.4.1
     - requests=2.22
     - tqdm
+    - zenodo_get
+    - pip
     - pip:
         - pycf3==2020.12

--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,6 @@ dependencies:
     - tqdm
     - zenodo_get
     - pip
+    - unzip
     - pip:
         - pycf3==2020.12

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# download data
+zenodo_get -r 6629552
+
+unzip HCG_VLA_HI_data_products.zip
+unzip GBT_spectra.zip
+unzip optical_images.zip


### PR DESCRIPTION

Update conda environment to
* include `pip`
* include `zenodo_get` as a more reliable way to download files from zenodo